### PR TITLE
Fix setting of environment variables

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -1,9 +1,12 @@
-cmake_package 'tools/orogen_cpp_proxies'
+cmake_package 'tools/orogen_cpp_proxies' do |pkg|
+    pkg.env_add_path 'OROGEN_PLUGIN_PATH', File.join(pkg.prefix, 'share','orogen','plugins')
+end
 cmake_package 'tools/orocos_cpp_base'
 cmake_package 'tools/orocos_cpp'
 cmake_package 'tools/orogen_model_exporter' do |pkg|
-	Autoproj.env_add_path 'PATH', File.join(pkg.srcdir, 'bin')
-    Autoproj.env_add_path 'RUBYLIB', File.join(pkg.srcdir, 'lib')
+    pkg.env_add_path 'PATH', File.join(pkg.srcdir, 'bin')
+    pkg.env_add_path 'RUBYLIB', File.join(pkg.srcdir, 'lib')
+    pkg.env_add_path 'OROGEN_PLUGIN_PATH', File.join(pkg.prefix, 'share','orogen','plugins')
 end
 cmake_package 'tools/lib_config'
 cmake_package 'tools/lib_init'

--- a/orogen.autobuild
+++ b/orogen.autobuild
@@ -1,5 +1,5 @@
 orogen_package 'tools/rtt_introspection' do |pkg|
-    Autoproj.env_add_path 'RTT_COMPONENT_PATH', File.join(pkg.prefix, "lib/orocos/plugins")
+    pkg.env_add_path 'RTT_COMPONENT_PATH', File.join(pkg.prefix, 'lib','orocos','plugins')
 end
 
 orogen_package 'tools/state_machine_tk'

--- a/overrides.rb
+++ b/overrides.rb
@@ -5,6 +5,3 @@ Autoproj.manifest.each_autobuild_package do |pkg|
     pkg.depends_on 'tools/orogen_model_exporter'
     pkg.orogen_options << '--extensions=cpp_proxies,modelExport'
  end
-
-Autoproj.env_add 'OROGEN_PLUGIN_PATH', File.join(Autoproj.root_dir, 'install/tools/orogen_cpp_proxies/', 'share', 'orogen', 'plugins')
-Autoproj.env_add 'OROGEN_PLUGIN_PATH', File.join(Autoproj.root_dir, 'install/tools/orogen_model_exporter/', 'share', 'orogen', 'plugins')


### PR DESCRIPTION
Fix the setting of the environment variable and make it agnostic to the setting of 
 Autoproj.config.separate_prefixes (in init.rb)