### PR TITLE
set OROGEN_MODEL_PATH to globally defined path …

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -11,7 +11,7 @@ cmake_package 'tools/orogen_model_exporter' do |pkg|
     FileUtils.mkdir_p pluginpath
     pkg.env_add_path 'OROGEN_PLUGIN_PATH', pluginpath
     
-    modelspath = File.join(pkg.prefix, 'share', 'orogen', 'models')
+    modelspath = File.join(Autoproj.prefix, 'share', 'orogen', 'models')
     FileUtils.mkdir_p modelspath
     pkg.env_set 'OROGEN_MODEL_PATH', modelspath
 end


### PR DESCRIPTION
... instead of package-relative path.
In case of separate build prefixes per package model files will get placed into common folder defined by OROGEN_MODEL_PATH

Note that install destination can be controlled with https://github.com/rock-cpp/orogen_model_exporter/pull/9