### PR TITLE
Remove obsolete tools/backward and update to newer version

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -26,7 +26,6 @@ remove_from_default 'tools/lib_init_optional'
 
 cmake_package 'tools/smurf'
 cmake_package 'tools/state_machine'
-cmake_package 'tools/backward'
 cmake_package 'tools/backward-cpp'
 cmake_package 'gui/rock-display'
 cmake_package 'gui/rock_replay'

--- a/source.yml
+++ b/source.yml
@@ -16,6 +16,9 @@ version_control:
     - tools/backward-cpp:
       github: bombela/backward-cpp
       tag: v1.5
+      patches:
+       - $AUTOPROJ_SOURCE_DIR/patches/0001-add-pkg-config.patch
+       - $AUTOPROJ_SOURCE_DIR/patches/0002-fix-installation-of-backward_config.hpp.patch
 
     - gui/.*:
       github: rock-cpp/$PACKAGE_BASENAME


### PR DESCRIPTION
'tools/backward' had some changes but is outdated, there was also a duplicate: tools/backward-cpp
This adds the changes as patches to tools/backward-cpp and removes 'tools/backward'