### PR TITLE
Removed import of rock.simulation.

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -2,7 +2,6 @@ name: rock.cpp
 
 imports:
     - github: rock-core/package_set
-    - github: rock-simulation/package_set
 
 version_control:
     - tools/.*:


### PR DESCRIPTION
Don't know why it was imported and should not depend on simulation in my opinion.